### PR TITLE
PLATEAU建築物GeoJSONレイヤを追加

### DIFF
--- a/apps/deckgl-react/components/control-panel.tsx
+++ b/apps/deckgl-react/components/control-panel.tsx
@@ -31,7 +31,7 @@ const DropDownContainer = styled.div`
 `;
 
 const DropDownLabel = styled.label`
-  width: 80px;
+  width: 60px;
   text-align: right;
 `;
 
@@ -47,7 +47,7 @@ const TilesetDropDownContainer = styled.div`
 `;
 
 const TilesetDropDownLabel = styled.label`
-  width: 80px;
+  width: 60px;
   text-align: right;
 `;
 
@@ -55,6 +55,22 @@ const TilesetDropDown = styled.select`
   margin-left: 6px;
   /* font-weight: 800; */
   font-size: 14px;
+`;
+
+const CheckBoxContainer = styled.div`
+  margin-bottom: 8px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const CheckBoxLabel = styled.label`
+  width: auto;
+  text-align: left;
+`;
+
+const CheckBox = styled.input.attrs({type: 'checkbox'})`
+  width: 60px;
 `;
 
 type ExampleChangeEvent = {
@@ -67,6 +83,10 @@ type MapStyleChangeEvent = {
   selectedMapStyle: string;
 };
 
+type GeoJsonVisibilityChangeEvent = {
+  geoJsonVisibility: boolean;
+};
+
 type ControlPanelProps = {
   category: string;
   name: string;
@@ -74,8 +94,10 @@ type ControlPanelProps = {
   tileset?: Tileset3D | null;
   mapStyles?: MapStyles;
   selectedMapStyle?: string;
+  geojsonVisibility: boolean;
   onExampleChange: (event: ExampleChangeEvent) => void;
   onMapStyleChange: (event: MapStyleChangeEvent) => void;
+  onGeoJsonVisibilityChange: (event: GeoJsonVisibilityChangeEvent) => void;
   children?: ReactNode;
 };
 
@@ -87,8 +109,10 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
   tileset,
   mapStyles = MAP_STYLES,
   selectedMapStyle = Object.values(MAP_STYLES)[0],
+  geojsonVisibility,
   onExampleChange,
   onMapStyleChange,
+  onGeoJsonVisibilityChange,
   children
 }: ControlPanelProps) => {
   const renderByCategories = () => {
@@ -154,10 +178,26 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
     );
   };
 
+  const renderGeoJsonVisibility = () => {
+    return (
+      <CheckBoxContainer>
+        <CheckBox
+          checked={geojsonVisibility}
+          onChange={(evt) => {
+            const checked = evt.target.checked;
+            onGeoJsonVisibilityChange({geoJsonVisibility: checked});
+          }}
+        />
+        <CheckBoxLabel>PLATEAU建築物GeoJSON</CheckBoxLabel>
+      </CheckBoxContainer>
+    );
+  };
+
   return (
     <Container>
       {renderByCategories()}
       {renderMapStyles()}
+      {renderGeoJsonVisibility()}
       {children}
     </Container>
   );

--- a/apps/deckgl-react/examples.ts
+++ b/apps/deckgl-react/examples.ts
@@ -42,3 +42,5 @@ function resolveUrls(exampleIndex: Index) {
     }
   }
 }
+
+export const PLATEAU_BUILDING_GEOJSON = `${DATA_URI}/plateau/geojson/bldg/Building.geojson`;

--- a/apps/deckgl-react/package.json
+++ b/apps/deckgl-react/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@types/geojson": "^7946.0.15",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@eslint/js':
         specifier: ^9.17.0
         version: 9.17.0
+      '@types/geojson':
+        specifier: ^7946.0.15
+        version: 7946.0.15
       '@types/react':
         specifier: ^18.3.18
         version: 18.3.18


### PR DESCRIPTION
[fosawa/plateau_example_deckgl](https://github.com/fosawa/plateau_example_deckgl) - 2024年7月22日「50行のコードからはじめるブラウザでのPLATEAU利用」のサンプル中、以下のGeoJSON表示コード箇所を参考にさせて頂きました。
* https://github.com/fosawa/plateau_example_deckgl/blob/main/web/06.html#L52-L69

その他、deck.glの [GeoJsonLayer APIリファレンス](https://deck.gl/docs/api-reference/layers/geojson-layer)も参考にしています。